### PR TITLE
Add an arbitrary interface to the router and tcpserver

### DIFF
--- a/request/router_test.go
+++ b/request/router_test.go
@@ -18,6 +18,7 @@ func TestAckUnknown(t *testing.T) {
 		// Intentionally left blank
 		},
 		cast,
+		"",
 	)
 
 	rs := make(chan *baps3.Message, 1)
@@ -47,11 +48,12 @@ func TestAckSuccess(t *testing.T) {
 
 	router := NewRouter(
 		map[baps3.MessageWord]Handler{
-			baps3.RqRead: func(_, _ chan<- *baps3.Message, _ []string) (bool, error) {
+			baps3.RqRead: func(_, _ chan<- *baps3.Message, _ []string, _ interface{}) (bool, error) {
 				return false, nil
 			},
 		},
 		cast,
+		"",
 	)
 
 	rs := make(chan *baps3.Message, 1)

--- a/tcpserver/server.go
+++ b/tcpserver/server.go
@@ -12,7 +12,7 @@ import (
 // Serve creates and runs a Bifrost server using TCP as a transport.
 // It will respond to requests using the functions in requestMap.
 // New clients will be served 'OHAI <serverid>'.
-func Serve(requestMap request.Map, serverid, hostport string) {
+func Serve(requestMap request.Map, arbitrary interface{}, serverid, hostport string) {
 	ln, err := net.Listen("tcp", hostport)
 	if err != nil {
 		log.Fatal(err)
@@ -34,7 +34,7 @@ func Serve(requestMap request.Map, serverid, hostport string) {
 
 	t.Go(func() error { return acceptLoop(ln, requests, p, &t) })
 
-	router := request.NewRouter(requestMap, p.Broadcast)
+	router := request.NewRouter(requestMap, p.Broadcast, arbitrary)
 	requestLoop(requests, router, &t)
 
 	if kerr := t.Killf("main loop closing"); kerr != nil {


### PR DESCRIPTION
I'm not entirely convinced by this, as it will only let you set a single interface, when you start the server/router. But, I can't think of anything else, so...

deferred to @CaptainHayashi 